### PR TITLE
Fix for php8 and CiviCRM 5.68 compatibility

### DIFF
--- a/checksums.civix.php
+++ b/checksums.civix.php
@@ -95,13 +95,7 @@ function _checksums_civix_civicrm_config(&$config = NULL) {
 
   $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
+  $template->addTemplateDir($extDir);
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);


### PR DESCRIPTION
@MegaphoneJon this PR fixes an issue on CiviCRM 5.68 and PHP 8. PHP 8 generates warning/errors about undefined class variables. 

Can you merge this and create a new version? That would be wonderful 